### PR TITLE
Add remoteuser authenticator

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ This is under active development, see the Issues list for current outstanding it
  * Authentication
    * [Okta identity cloud](https://okta.com/)
    * Static configured users with support for basic agent+action ACLs as well as Open Policy Agent policies
+   * Login delegation via X-Remote-User
    * Capable of running centrally separate from signers
    * Supports setting the Choria Organization claim for multi tenancy (not for okta users)
  * Authorization
@@ -311,6 +312,29 @@ Once you signed up for Okta and set up a application for Choria you'll get endpo
 ```
 
 Here we configure `acls` based on Okta groups - all users can `rpcutil ping`, there are Puppet admins with appropriate rights and fleet wide admins capable of managing anything.
+
+#### Login delegation via `X-Remote-User`
+
+It's possible to delegate the responsibility of verifying the users' identity to a front-end configured using the mechanism of your choice (Kerberos, OIDC, etc) and setting the identity of the caller in the `X-Remote-User` HTTP header. In this case, configure the `remoteuser` authenticator and make sure that the entrypoint `/login` is well protected. All users will receive the same ACLs et al, configured via `default_user`.
+
+```json
+{
+  "authenticator": "remoteuser",
+  "remote_authenticator": {
+    "validity": "1h",
+    "signing_key": "/etc/choria/signer/signing_key.pem",
+    "default_user": {
+        "acls": [
+            "puppet.*"
+        ],
+        "properties": {
+            "group": "users"
+        },
+        "organization": "acme"
+    }
+  }
+}
+```
 
 ## Authorization
 

--- a/api/gen/restapi/embedded_spec.go
+++ b/api/gen/restapi/embedded_spec.go
@@ -45,10 +45,15 @@ func init() {
             "description": "The Login request",
             "name": "request",
             "in": "body",
-            "required": true,
             "schema": {
               "$ref": "#/definitions/LoginRequest"
             }
+          },
+          {
+            "type": "string",
+            "description": "The remote user",
+            "name": "X-Remote-User",
+            "in": "header"
           }
         ],
         "responses": {
@@ -178,10 +183,15 @@ func init() {
             "description": "The Login request",
             "name": "request",
             "in": "body",
-            "required": true,
             "schema": {
               "$ref": "#/definitions/LoginRequest"
             }
+          },
+          {
+            "type": "string",
+            "description": "The remote user",
+            "name": "X-Remote-User",
+            "in": "header"
           }
         ],
         "responses": {

--- a/api/gen/restapi/operations/post_login.go
+++ b/api/gen/restapi/operations/post_login.go
@@ -44,7 +44,7 @@ type PostLogin struct {
 func (o *PostLogin) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewPostLoginParams()
 	if err := o.Context.BindValidRequest(r, route, &Params); err != nil { // bind params

--- a/api/gen/restapi/operations/post_sign.go
+++ b/api/gen/restapi/operations/post_sign.go
@@ -44,7 +44,7 @@ type PostSign struct {
 func (o *PostSign) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewPostSignParams()
 	if err := o.Context.BindValidRequest(r, route, &Params); err != nil { // bind params

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -21,9 +21,14 @@ paths:
       - in: "body"
         name: "request"
         description: "The Login request"
-        required: true
+        required: false
         schema:
           $ref: "#/definitions/LoginRequest"
+      - in: "header"
+        name: "X-Remote-User"
+        description: "The remote user"
+        required: false
+        type: string
 
       responses:
         "200":

--- a/authenticators/authenticators.go
+++ b/authenticators/authenticators.go
@@ -13,7 +13,7 @@ var mu = &sync.Mutex{}
 
 // Authenticator providers user authentication
 type Authenticator interface {
-	Login(*models.LoginRequest) *models.LoginResponse
+	Login(*models.LoginRequest, *string) *models.LoginResponse
 }
 
 // SetAuthenticator sets the authenticator to use
@@ -33,5 +33,5 @@ func LoginHandler(params operations.PostLoginParams) middleware.Responder {
 		return operations.NewPostLoginOK().WithPayload(&models.LoginResponse{Error: "No authenticator configured"})
 	}
 
-	return operations.NewPostLoginOK().WithPayload(authenticator.Login(params.Request))
+	return operations.NewPostLoginOK().WithPayload(authenticator.Login(params.Request, params.XRemoteUser))
 }

--- a/authenticators/okta/okta.go
+++ b/authenticators/okta/okta.go
@@ -68,7 +68,7 @@ func New(c *AuthenticatorConfig, log *logrus.Entry, site string) (a *Authenticat
 }
 
 // Login logs someone in using Okta
-func (a *Authenticator) Login(req *models.LoginRequest) (resp *models.LoginResponse) {
+func (a *Authenticator) Login(req *models.LoginRequest, ru *string) (resp *models.LoginResponse) {
 	timer := authenticators.ProcessTime.WithLabelValues(a.site, "okta")
 	obs := prometheus.NewTimer(timer)
 	defer obs.ObserveDuration()
@@ -87,6 +87,12 @@ func (a *Authenticator) Login(req *models.LoginRequest) (resp *models.LoginRespo
 
 func (a *Authenticator) processLogin(req *models.LoginRequest) (resp *models.LoginResponse) {
 	resp = &models.LoginResponse{}
+
+	if req == nil {
+		a.log.Warnf("Login failed due to missing message body")
+		resp.Error = "Login failed"
+		return
+	}
 
 	_, _, err := a.login(req.Username, req.Password)
 	if err != nil {

--- a/authenticators/remoteuser/defaultuser.go
+++ b/authenticators/remoteuser/defaultuser.go
@@ -1,0 +1,48 @@
+package remoteuser
+
+import (
+	"io/ioutil"
+	"sync"
+)
+
+// DefaulUser is a choria user without user and/or password
+type DefaultUser struct {
+	// Organization is a org name the user belongs to
+	Organization string `json:"organization"`
+
+	// ACLs are for the action list authorizer
+	ACLs []string `json:"acls"`
+
+	// OPAPolicy is a string holding a Open Policy Agent rego policy
+	OPAPolicy string `json:"opa_policy"`
+
+	// OPAPolicyFile is the path to a rego file to embed as the policy for this user
+	OPAPolicyFile string `json:"opa_policy_file"`
+
+	// Properties are free form additional information to add about a user, this can be
+	// referenced later in an authorizer like the Open Policy one
+	Properties map[string]string `json:"properties"`
+
+	sync.Mutex
+}
+
+// OpenPolicy retrieves the OPA Policy either from `OPAPolicy` or by reading the file in `OPAPolicyFile`
+func (u DefaultUser) OpenPolicy() (policy string, err error) {
+	u.Lock()
+	defer u.Unlock()
+
+	if u.OPAPolicy != "" {
+		return u.OPAPolicy, nil
+	}
+
+	if u.OPAPolicyFile == "" {
+		return "", nil
+	}
+
+	out, err := ioutil.ReadFile(u.OPAPolicyFile)
+	if err != nil {
+		return "", err
+	}
+
+	return string(out), nil
+}

--- a/authenticators/remoteuser/remoteuser.go
+++ b/authenticators/remoteuser/remoteuser.go
@@ -1,0 +1,152 @@
+// Package remoteuser provides an authentication system with login delegation
+//
+// The user's identity validation is delegated to a front-end. This authenticator
+// simply consumes the value of the X-Remote-User HTTP header and generates a signed
+// authentication token with the same ACLs for all users.
+//
+// In the future, per-user ACLs/roles/etc could even be part of other
+// headers. Alternatively, there could also be a local DB here (as in
+// the userlist authenticator). Or a even a combination of both!
+package remoteuser
+
+import (
+	"crypto/rsa"
+	"fmt"
+	"io/ioutil"
+	"sync"
+	"time"
+
+	"github.com/choria-io/aaasvc/api/gen/models"
+	"github.com/choria-io/aaasvc/authenticators"
+	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
+)
+
+// AuthenticatorConfig configures the remoteuser authenticator
+type AuthenticatorConfig struct {
+	DefaultUser   DefaultUser `json:"default_user"`
+	TokenValidity string      `json:"validity"`
+	SigningKey    string      `json:"signing_key"`
+}
+
+// Authenticator is an authenticator blindly trusting X-Remote-User and using a default config for all users
+type Authenticator struct {
+	c             *AuthenticatorConfig
+	validity      time.Duration
+	log           *logrus.Entry
+	site          string
+	userFileMtime time.Time
+	sync.Mutex
+}
+
+// New creates an instance of the authenticator
+func New(c *AuthenticatorConfig, log *logrus.Entry, site string) (a *Authenticator, err error) {
+	validity, err := time.ParseDuration(c.TokenValidity)
+	if err != nil {
+		return nil, errors.Wrap(err, "invalid token validity")
+	}
+
+	a = &Authenticator{
+		c:        c,
+		validity: validity,
+		log:      log.WithField("authenticator", "remoteuser"),
+		site:     site,
+	}
+
+	return a, nil
+}
+
+// Login logs a pre-authenticated user filling the token with a default user template
+func (a *Authenticator) Login(req *models.LoginRequest, ru *string) (resp *models.LoginResponse) {
+	timer := authenticators.ProcessTime.WithLabelValues(a.site, "remoteuser")
+	obs := prometheus.NewTimer(timer)
+	defer obs.ObserveDuration()
+
+	resp = a.processLogin(ru)
+	if resp.Error != "" {
+		authenticators.ErrCtr.WithLabelValues(a.site, "remoteuser").Inc()
+	}
+
+	return resp
+}
+
+func (a *Authenticator) processLogin(ru *string) (resp *models.LoginResponse) {
+	resp = &models.LoginResponse{}
+
+	if ru == nil || len(*ru) == 0 {
+		a.log.Warnf("Login failed as there was no X-Remote-User present in the request")
+		resp.Error = "Login failed"
+		return
+	}
+
+	remoteuser := *ru
+
+	claims := map[string]interface{}{
+		"exp":      time.Now().UTC().Add(a.validity).Unix(),
+		"nbf":      time.Now().UTC().Add(-1 * time.Minute).Unix(),
+		"iat":      time.Now().UTC().Unix(),
+		"iss":      "Choria Remoteuser Authenticator",
+		"callerid": fmt.Sprintf("up=%s", remoteuser),
+		"sub":      "choria_client",
+		"agents":   a.c.DefaultUser.ACLs,
+		"ou":       "choria",
+	}
+
+	if a.c.DefaultUser.Organization != "" {
+		claims["ou"] = a.c.DefaultUser.Organization
+	}
+
+	policy, err := a.c.DefaultUser.OpenPolicy()
+	if err != nil {
+		a.log.Warnf("Reading OPA policy for user %s failed: %s", remoteuser, err)
+		resp.Error = "Login failed"
+		return
+	}
+
+	if len(a.c.DefaultUser.Properties) > 0 {
+		claims["user_properties"] = a.c.DefaultUser.Properties
+	}
+
+	if policy != "" {
+		claims["opa_policy"] = policy
+	}
+
+	token := jwt.NewWithClaims(jwt.GetSigningMethod("RS512"), jwt.MapClaims(claims))
+
+	signKey, err := a.signKey()
+	if err != nil {
+		a.log.Errorf("Could not load signing key during login request for user %s: %s: %s", remoteuser, a.c.SigningKey, err)
+		resp.Error = "Could not load signing key from disk"
+		return
+	}
+
+	signed, err := token.SignedString(signKey)
+	if err != nil {
+		a.log.Errorf("Could not sign JWT for %s: %s", remoteuser, err)
+		resp.Error = "Could not sign JWT token"
+		return
+	}
+
+	resp.Token = signed
+
+	a.log.Infof("Logged in user %s", remoteuser)
+
+	return resp
+
+}
+
+func (a *Authenticator) signKey() (*rsa.PrivateKey, error) {
+	pkeyBytes, err := ioutil.ReadFile(a.c.SigningKey)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not read")
+	}
+
+	signKey, err := jwt.ParseRSAPrivateKeyFromPEM(pkeyBytes)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not parse")
+	}
+
+	return signKey, nil
+}

--- a/authenticators/remoteuser/remoteuser_test.go
+++ b/authenticators/remoteuser/remoteuser_test.go
@@ -1,11 +1,9 @@
-package userlist
+package remoteuser
 
 import (
 	"crypto/rsa"
 	"io/ioutil"
-	"os"
 	"testing"
-	"time"
 
 	"github.com/choria-io/aaasvc/api/gen/models"
 	jwt "github.com/dgrijalva/jwt-go"
@@ -16,10 +14,10 @@ import (
 
 func TestWithGinkgo(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Authenticators/Userlist")
+	RunSpecs(t, "Authenticators/Remoteuser")
 }
 
-var _ = Describe("Authenticators/Userlist", func() {
+var _ = Describe("Authenticators/Remoteuser", func() {
 	var (
 		conf *AuthenticatorConfig
 		req  *models.LoginRequest
@@ -30,16 +28,12 @@ var _ = Describe("Authenticators/Userlist", func() {
 
 	BeforeEach(func() {
 		conf = &AuthenticatorConfig{
-			SigningKey:    "testdata/key.pem",
+			SigningKey:    "../userlist/testdata/key.pem",
 			TokenValidity: "1h",
-			Users: []*User{
-				&User{
-					Username:      "bob",
-					Password:      "$2a$06$chB5d2pCKEzM6xlDoPvofuKW52piJ5f8fGvxHPTDaeSJOSNY76yai",
-					ACLs:          []string{"*"},
-					OPAPolicyFile: "testdata/test.rego",
-					Properties:    map[string]string{"group": "admins"},
-				},
+			DefaultUser: DefaultUser{
+				ACLs:          []string{"puppet.*"},
+				OPAPolicyFile: "../userlist/testdata/test.rego",
+				Properties:    map[string]string{"group": "admins"},
 			},
 		}
 
@@ -65,57 +59,19 @@ var _ = Describe("Authenticators/Userlist", func() {
 		})
 	})
 
-	Describe("reloadUserFile", func() {
-		It("Should handle no file specified", func() {
-			conf.UsersFile = ""
-			read, err := auth.reloadUserFile()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(read).To(BeFalse())
-		})
-
-		It("Should read a file and not reread it again if not needed", func() {
-			conf.UsersFile = "testdata/users.json"
-			read, err := auth.reloadUserFile()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(read).To(BeTrue())
-
-			Expect(auth.c.Users[0].Username).To(Equal("from_file"))
-
-			read, err = auth.reloadUserFile()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(read).To(BeFalse())
-		})
-
-		It("Should reread a file when needed", func() {
-			conf.UsersFile = "testdata/users.json"
-			read, err := auth.reloadUserFile()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(read).To(BeTrue())
-			Expect(auth.c.Users[0].Username).To(Equal("from_file"))
-
-			now := time.Now()
-			err = os.Chtimes("testdata/users.json", now, now)
-			Expect(err).ToNot(HaveOccurred())
-
-			read, err = auth.reloadUserFile()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(read).To(BeTrue())
-			Expect(auth.c.Users[0].Username).To(Equal("from_file"))
-
-			read, err = auth.reloadUserFile()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(read).To(BeFalse())
-		})
-	})
-
 	Describe("Login", func() {
-		It("Should handle invalid users", func() {
-			req.Username = "invalid"
+		It("Should handle non-existent X-Remote-User", func() {
 			res := auth.Login(req, nil)
 			Expect(res.Error).To(Equal("Login failed"))
 		})
 
-		It("Should handle invalid password", func() {
+		It("Should handle empty X-Remote-User", func() {
+			remoteuser := ""
+			res := auth.Login(req, &remoteuser)
+			Expect(res.Error).To(Equal("Login failed"))
+		})
+
+		It("Should ignore any user/passwd pair", func() {
 			req.Username = "bob"
 			req.Password = "fooo"
 			res := auth.Login(req, nil)
@@ -124,8 +80,9 @@ var _ = Describe("Authenticators/Userlist", func() {
 
 		It("Should generate correct claims", func() {
 			req.Username = "bob"
-			req.Password = "secret"
-			res := auth.Login(req, nil)
+			req.Password = "doesnotmatter"
+			remoteuser := "alice"
+			res := auth.Login(req, &remoteuser)
 			Expect(res.Error).To(Equal(""))
 
 			pub, err := signKey()
@@ -141,16 +98,16 @@ var _ = Describe("Authenticators/Userlist", func() {
 
 			caller, ok := claims["callerid"].(string)
 			Expect(ok).To(BeTrue())
-			Expect(caller).To(Equal("up=bob"))
+			Expect(caller).To(Equal("up=alice"))
 
 			agents, ok := claims["agents"].([]interface{})
 			Expect(ok).To(BeTrue())
 			Expect(agents).To(HaveLen(1))
-			Expect(agents[0].(string)).To(Equal("*"))
+			Expect(agents[0].(string)).To(Equal("puppet.*"))
 
 			policy, ok := claims["opa_policy"].(string)
 			Expect(ok).To(BeTrue())
-			Expect(policy).To(Equal(readFixture("testdata/test.rego")))
+			Expect(policy).To(Equal(readFixture("../userlist/testdata/test.rego")))
 
 			props, ok := claims["user_properties"].(map[string]interface{})
 			Expect(ok).To(BeTrue())
@@ -171,7 +128,7 @@ func readFixture(f string) string {
 }
 
 func signKey() (*rsa.PublicKey, error) {
-	certBytes, err := ioutil.ReadFile("testdata/cert.pem")
+	certBytes, err := ioutil.ReadFile("../userlist/testdata/cert.pem")
 	if err != nil {
 		return nil, err
 	}

--- a/authenticators/userlist/userlist.go
+++ b/authenticators/userlist/userlist.go
@@ -59,7 +59,7 @@ func New(c *AuthenticatorConfig, log *logrus.Entry, site string) (a *Authenticat
 }
 
 // Login logs someone in using a configured user list
-func (a *Authenticator) Login(req *models.LoginRequest) (resp *models.LoginResponse) {
+func (a *Authenticator) Login(req *models.LoginRequest, ru *string) (resp *models.LoginResponse) {
 	timer := authenticators.ProcessTime.WithLabelValues(a.site, "userlist")
 	obs := prometheus.NewTimer(timer)
 	defer obs.ObserveDuration()
@@ -74,6 +74,12 @@ func (a *Authenticator) Login(req *models.LoginRequest) (resp *models.LoginRespo
 
 func (a *Authenticator) processLogin(req *models.LoginRequest) (resp *models.LoginResponse) {
 	resp = &models.LoginResponse{}
+
+	if req == nil {
+		a.log.Warnf("Login failed due to missing message body")
+		resp.Error = "Login failed"
+		return
+	}
 
 	user, err := a.getUser(req.Username)
 	if err != nil {


### PR DESCRIPTION
See https://github.com/nbarrientos/aaasvc/blob/issue84/README.md#login-delegation-via-x-remote-user

For "internal" comsumption only (needs discussion upstream):

```
~/dev/aaasvc λ curl -s --request POST -d '{"username":"ignored"}' -H "Content-type: application/json" -k http://localhost:8080/choria/v1/login -H 'X-Remote-User:nacho'
{"token":"eyJhbGciOiJSUzUxMiIsI..."}
```
```
(dlv) p claims
map[string]interface {} [
	"exp": 1618739030, 
	"nbf": 1618735370, 
	"iat": 1618735430, 
	"sub": "choria_client", 
	"agents": []string len: 1, cap: 4, [
		"puppet.*",
	], 
	"iss": "Choria Remoteuser Authenticator", 
	"callerid": "up=nacho", 
	"ou": "cern", 
	"user_properties": map[string]string [
		"group": "admins", 
	], 
]
```

With config:

```json
{
  "logfile": "aaasvc.log",
  "loglevel": "info",
  "choria_config": "choria.conf",
  "authenticator": "remoteuser",
  "auditors": [
    "logfile"
  ],
  "authorizer": "actionlist",
  "signer": "basicjwt",
  "port": 8080,
  "monitor_port": 8081,
  "site": "default",
  "tls_certificate": "",
  "tls_key": "",
  "tls_ca": "",
  "basicjwt_signer": {
    "signing_certificate": "signing_pub.pem",
    "max_validity": "24h"
  },
  "logfile_auditor": {
    "logfile": "audit.log"
  },
  "remoteuser_authenticator": {
    "signing_key": "signing_key.pem",
    "validity": "1h",
    "default_user": {
        "acls": [
            "puppet.*"
        ],
        "properties": {
            "group": "admins"
        },
        "organization": "cern"
    }
  }
}
```

To be discussed in https://github.com/choria-io/aaasvc/issues/84. We need though something quick to unblock the testing/validation.